### PR TITLE
Feature/blank strings in bpt

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ tests:
     - hspec
     - hspec-discover
     - QuickCheck
+    - quickcheck-instances
 
 
 verbatim:

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -7,6 +7,4 @@ data Title = InvalidTitle | ValidTitle String deriving (Eq, Show)
 
 isTitleValid :: String -> Title
 isTitleValid "" = InvalidTitle
--- isTitleValid " " = InvalidTitle
-isTitleValid t  = ValidTitle t
-
+isTitleValid t = ValidTitle t

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -2,6 +2,8 @@ module Lib where
 
 import Control.Monad (mfilter)
 import Data.Char (isSpace)
+import Data.List (dropWhileEnd)
+import Data.Text (strip)
 
 someFunc :: IO ()
 someFunc = putStrLn "someFunc"
@@ -10,17 +12,18 @@ data Title = InvalidTitle | ValidTitle String deriving (Eq, Show)
 
 isTitleValid :: String -> Title
 isTitleValid "" = InvalidTitle
--- isTitleValid t | all isSpace t = InvalidTitle
 isTitleValid t = ValidTitle t
 
--- Approach 2
-f "" = Nothing
-f s = Just s
+nonEmptyTitle "" = Nothing
+nonEmptyTitle s = Just s
 
-isTitleValid2 = f . trim
+title = title2
 
-trim :: String -> String
-trim s = undefined
+title2 = nonEmptyTitle . trim
+
+title3 = nonEmptyTitle . strip
+
+trim = dropWhileEnd isSpace . dropWhile isSpace
 
 -- Approach 3
 

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,5 +1,8 @@
 module Lib where
 
+import Control.Monad (mfilter)
+import Data.Char (isSpace)
+
 someFunc :: IO ()
 someFunc = putStrLn "someFunc"
 
@@ -7,4 +10,18 @@ data Title = InvalidTitle | ValidTitle String deriving (Eq, Show)
 
 isTitleValid :: String -> Title
 isTitleValid "" = InvalidTitle
+-- isTitleValid t | all isSpace t = InvalidTitle
 isTitleValid t = ValidTitle t
+
+-- Approach 2
+f "" = Nothing
+f s = Just s
+
+isTitleValid2 = f . trim
+
+trim :: String -> String
+trim s = undefined
+
+-- Approach 3
+
+f' s = mfilter (all isSpace) (Just s)

--- a/test/LibSpec.hs
+++ b/test/LibSpec.hs
@@ -21,7 +21,7 @@ positiveNumberGen = fmap abs arbitrary
 spec :: Spec
 spec = describe "TodoApp tests" $ do
   prop "title is not valid if empty or blank" $
-    \s -> all isSpace s ==> isTitleValid s == InvalidTitle
+    \t -> all isSpace t ==> isTitleValid t == InvalidTitle
 
   prop "title is valid whenver it's not empty or blank" $
     \t -> (not . all isSpace) t ==> isTitleValid t == ValidTitle t

--- a/test/LibSpec.hs
+++ b/test/LibSpec.hs
@@ -1,16 +1,12 @@
 module LibSpec where
 
 import Data.Char
-import Lib
+import Data.Maybe (isJust, isNothing)
+import Lib (title)
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 import Test.QuickCheck.Property
-
--- import Test.QuickCheck.Gen
-
--- simpleGen :: Gen String
--- simpleGen = ...
 
 spaceCharGen :: Gen Char
 spaceCharGen = suchThat arbitrary isSpace
@@ -18,19 +14,12 @@ spaceCharGen = suchThat arbitrary isSpace
 emptyOrBlankStringGen :: Gen String
 emptyOrBlankStringGen = listOf spaceCharGen
 
-positiveNumberGen :: Gen Int
-positiveNumberGen = fmap abs arbitrary
-
---                  baseGen.map(i => return abs(i))
---                  baseGen.map(abs)
-
 spec :: Spec
 spec = describe "TodoApp tests" $ do
   modifyMaxSuccess (const 5000) $
     prop "title is not valid if empty or blank" $
-      forAll emptyOrBlankStringGen $
-        \t -> isTitleValid t == InvalidTitle
+      forAll emptyOrBlankStringGen $ \t -> isNothing $ title t
 
   modifyMaxSuccess (const 5000) $
     prop "title is valid whenver it's not empty or blank" $
-      \t -> (not . all isSpace) t ==> isTitleValid t /= InvalidTitle
+      \t -> (not . all isSpace) t ==> isJust $ title t

--- a/test/LibSpec.hs
+++ b/test/LibSpec.hs
@@ -12,6 +12,12 @@ import Test.QuickCheck.Property
 -- simpleGen :: Gen String
 -- simpleGen = ...
 
+spaceCharGen :: Gen Char
+spaceCharGen = suchThat arbitrary isSpace
+
+emptyOrBlankStringGen :: Gen String
+emptyOrBlankStringGen = listOf spaceCharGen
+
 positiveNumberGen :: Gen Int
 positiveNumberGen = fmap abs arbitrary
 
@@ -20,8 +26,11 @@ positiveNumberGen = fmap abs arbitrary
 
 spec :: Spec
 spec = describe "TodoApp tests" $ do
-  prop "title is not valid if empty or blank" $
-    \t -> all isSpace t ==> isTitleValid t == InvalidTitle
+  modifyMaxSuccess (const 5000) $
+    prop "title is not valid if empty or blank" $
+      forAll emptyOrBlankStringGen $
+        \t -> isTitleValid t == InvalidTitle
 
-  prop "title is valid whenver it's not empty or blank" $
-    \t -> (not . all isSpace) t ==> isTitleValid t == ValidTitle t
+  modifyMaxSuccess (const 5000) $
+    prop "title is valid whenver it's not empty or blank" $
+      \t -> (not . all isSpace) t ==> isTitleValid t /= InvalidTitle

--- a/test/LibSpec.hs
+++ b/test/LibSpec.hs
@@ -20,10 +20,8 @@ positiveNumberGen = fmap abs arbitrary
 
 spec :: Spec
 spec = describe "TodoApp tests" $ do
-  modifyMaxSuccess (const 10000) $
-    prop "title is not valid if empty or blank" $
-      \s -> all isSpace s ==> isTitleValid s == InvalidTitle
+  prop "title is not valid if empty or blank" $
+    \s -> all isSpace s ==> isTitleValid s == InvalidTitle
 
-  modifyMaxSuccess (const 10000) $
-    prop "title is valid whenver it's not empty or blank" $
-      \t -> (not . all isSpace) t ==> isTitleValid t == ValidTitle t
+  prop "title is valid whenver it's not empty or blank" $
+    \t -> (not . all isSpace) t ==> isTitleValid t == ValidTitle t

--- a/test/LibSpec.hs
+++ b/test/LibSpec.hs
@@ -1,10 +1,12 @@
 module LibSpec where
 
+import Data.Char
+import Lib
 import Test.Hspec
 import Test.Hspec.QuickCheck
-import Test.QuickCheck.Property
-import Lib
 import Test.QuickCheck
+import Test.QuickCheck.Property
+
 -- import Test.QuickCheck.Gen
 
 -- simpleGen :: Gen String
@@ -12,17 +14,16 @@ import Test.QuickCheck
 
 positiveNumberGen :: Gen Int
 positiveNumberGen = fmap abs arbitrary
+
 --                  baseGen.map(i => return abs(i))
 --                  baseGen.map(abs)
 
 spec :: Spec
 spec = describe "TodoApp tests" $ do
+  modifyMaxSuccess (const 10000) $
+    prop "title is not valid if empty or blank" $
+      \s -> all isSpace s ==> isTitleValid s == InvalidTitle
 
-     it "title is not valid if empty" $
-         isTitleValid "" `shouldBe` InvalidTitle
-
-     modifyMaxSuccess (const 50000) $ prop "title is valid when not empty" $
-         \ t -> not (null t) ==> isTitleValid t == ValidTitle t
-
-     -- prop "title is not valid when it only contains blanks" $
-        -- \ t -> isTitleValid t == InvalidTitle
+  modifyMaxSuccess (const 10000) $
+    prop "title is valid whenver it's not empty or blank" $
+      \t -> (not . all isSpace) t ==> isTitleValid t == ValidTitle t

--- a/todo-app-cli.cabal
+++ b/todo-app-cli.cabal
@@ -1,8 +1,10 @@
 cabal-version: 3.0
 
--- This file has been generated from package.yaml by hpack version 0.34.3.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: a838a508436a52c8f6e879d7d6ea65ebd424125d3289180780a55fce30cc8d2e
 
 name:           todo-app-cli
 version:        0.1.0.0
@@ -54,6 +56,7 @@ test-suite todo-app-cli-test
     , containers
     , hspec
     , hspec-discover
+    , quickcheck-instances
     , text
     , todo-app-cli
   default-language: Haskell2010


### PR DESCRIPTION
Fix/improve PBTs for title validation to take into account also blank strings. 

Conceptually speaking, the property that we want to express is this: **title is invalid if and only if it's empty or blank string**

This means that every empty or blank string must return invalid title, and also that there is no any other string that would result in a invalid title. 

Instead of writing one unique PBT to check **if and only if** we split into two tests: one for the "if" case, and one for the "only if" case. 

Haskell provides a function `isSpace :: Char -> Bool` to check whether a single char is a space or not. We can use `all` / `any` functions on lists to check whether the string contains any character which is not a space, and express the property in terms of preconditions on the inputs. 

Ideally, the "only if" part of the property literally reads
```
 \t -> isTitleValid t == InvalidTitle  ==> all isSpace t                                 (1) 
```
(which mirrors the "if" property), however this is one of those points where mathematics/formal verification and PBTs might diverge because of the different nature of the tools. Eq (1) in fact is not very efficient and effective with quickcheck: the default generator is sufficiently unbiased about our usecase that quickcheck would have to generate tons of characters and disregard most of them to try to disprove eq (1). Essentially, eq (1) has a precondition that we expect to be satisfied only on very specific cornercases , compared to the infinite ocean of possible arbitrary strings that we can generate. 

We have to approaches at this point. Either keep eq (1) but replace the underlying generator with a more biased one that is more likely to produce characters that will satisfy the precondition, or we can rephrase the precondition to something different like 
```
 \t -> (not . all isSpace) t ==> isTitleValid t == ValidTitle t       (2)
```
Eq (2) is logically equivalent to eq (1) but more effective for quickcheck. 


I've also removed the usage of `modifyMaxSuccess` that is not currently needed. 

Obviously now the tests are failing as expected because the implementation does not take into account blank lines