### PR TITLE
optparser for CLI args parsing

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Lib
+import TodoApp
 
 main :: IO ()
-main = someFunc
+main = program

--- a/package.yaml
+++ b/package.yaml
@@ -6,6 +6,8 @@ dependencies:
 - text
 - containers
 - either
+- optparse-applicative
+- optparse-generic  
 
 default-extensions:
 - OverloadedStrings

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,6 +1,5 @@
 module Lib
-  ( someFunc,
-    TodoValidationError (..),
+  ( TodoValidationError (..),
     checkTodo,
     checkTodo',
     trim,
@@ -14,10 +13,6 @@ import Control.Monad
 import Data.Char (isSpace)
 import Data.Either.Combinators (mapLeft, maybeToRight)
 import Data.List (dropWhileEnd)
-
-someFunc :: IO ()
-someFunc = do
-  putStrLn "someFunc"
 
 data Todo s a = Todo
   { description :: s,
@@ -42,12 +37,12 @@ checkTodo1 s a b = Right $ Todo s a b
 
 checkTodo2 :: Ord p => String -> Maybe p -> p -> Either TodoValidationError (Todo String p)
 checkTodo2 s a b = do
-  t <- maybeToRight TitleEmpty (checkTitle s)
+  t <- mapLeft (const TitleEmpty) (checkTitle s)
   d <- mapLeft (const PastDueDate) (checkDueDate b a)
   return $ Todo t d b
 
-checkTitle :: String -> Maybe String
-checkTitle = mfilter (not . null . trim) . Just
+checkTitle :: String -> Either () String
+checkTitle = maybeToRight () . mfilter (not . null . trim) . Just
 
 checkDueDate :: Ord p => p -> Maybe p -> Either () (Maybe p)
 checkDueDate n = traverse f

--- a/src/TodoApp.hs
+++ b/src/TodoApp.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module TodoApp where
+
+import qualified Lib as L
+import Options.Applicative
+import Options.Generic
+
+program :: IO ()
+program = do
+  -- todoInput <- execParser todoInputParserInfo
+  todoInput <- getRecord "helper message"
+  run todoInput
+
+run :: TodoInput -> IO ()
+run t = do
+  let v = L.checkTodo (title t) (dueDate t) 0
+  putStrLn $ show t
+  putStrLn $ render v
+
+render :: Show p => Either L.TodoValidationError (L.Todo String p) -> String
+render (Left L.TitleEmpty) = "please insert a non-empty title"
+render (Left L.PastDueDate) = "due date has to be in the future, if present"
+render (Right v) = "valid Todo " ++ (show v)
+
+-- manual applicative parser
+todoInputParser :: Parser TodoInput
+todoInputParser =
+  TodoInput
+    <$> strOption (long "title")
+    <*> optional (option auto (long "dueDate"))
+    <*> switch (long "verbose")
+
+todoInputParserInfo :: ParserInfo TodoInput
+todoInputParserInfo = info todoInputParser fullDesc
+
+data TodoInput = TodoInput
+  { title :: String,
+    dueDate :: Maybe Int,
+    verbose :: Bool
+  }
+  deriving (Generic, Eq, Show)
+
+instance ParseRecord TodoInput


### PR DESCRIPTION
* i've kept the code for the manual applicative parser , although the application code uses the automatically generated one using ghc generic extension
* i still have to write some test for the IO part and for the parser (although the definition of parser at this point is mostly declarative). i'll add some tests tomorrow 


Notice: the application is still not persisting the todos in some local file. We will add the storage in another PR